### PR TITLE
Changed name of "peity" data attribute to "_peity"

### DIFF
--- a/ng-peity.js
+++ b/ng-peity.js
@@ -76,7 +76,7 @@ var ngPeity = angular.module( 'ng-peity', [] )
 
                 // Redraw
                 var delayedResize = debounce(function() {
-                    var peity = chart.data().peity;
+                    var peity = chart.data()._peity;
                     peity.draw();
                 }, 300);
                 angular.element($window).bind('resize', delayedResize);
@@ -90,7 +90,7 @@ var ngPeity = angular.module( 'ng-peity', [] )
                 
                 // Update options
                 scope.$watch('options', function (newVal, oldVal) {
-                    var peity = chart.data().peity;
+                    var peity = chart.data()._peity;
                     peity.opts = $.extend(peity.opts, newVal);
                     peity.draw();
                 });


### PR DESCRIPTION
Changed name of "peity" data attribute to "_peity" to reflect changes made to jquery.peity.js with commit https://github.com/benpickles/peity/commit/a7e470d9ea5182d16d7d6def84a59a45a67d0e74 
This is required if using the latest versions of peity otherwise the redraw or update options functions will error and fail. Appears to run fine after these changes but there may be more subtle errors caused by the recent changes to peity.
